### PR TITLE
added solution for localize scripts on an easy way

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,6 +18,7 @@ $sage_includes = [
   'lib/wrapper.php',   // Theme wrapper class
   'lib/customizer.php', // Theme customizer
   'lib/wp_bootstrap_navwalker.php', // Boostrap Navigation
+  'lib/cubetech/localize.php', // cubetech JS Localize
 ];
 
 foreach ($sage_includes as $file) {

--- a/lib/cubetech/localize.php
+++ b/lib/cubetech/localize.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Roots\Sage\Cubetech;
+
+/**
+ * Localize dat script
+ * You can add own domains and values
+ */
+function ct_localize_scripts() {
+	wp_localize_script( 'sage/js', 'projectsAjax', array(
+		'url' => admin_url( 'admin-ajax.php' )
+	));
+}
+
+// Execute it after script is registered
+add_action('wp_loaded', __NAMESPACE__ . '\\ct_localize_scripts')
+
+?>

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -104,3 +104,11 @@ function assets() {
   wp_enqueue_script('sage/js', Assets\asset_path('scripts/main.js'), ['jquery'], null, true);
 }
 add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\assets', 100);
+
+/**
+ * Register scripts - so we can localize later
+ */
+function register_scripts() {
+	wp_register_script('sage/js', Assets\asset_path('scripts/main.js'), ['jquery'], null, true);
+}
+add_action('init', __NAMESPACE__ . '\\register_scripts');


### PR DESCRIPTION
added solution for localize scripts on a easy way:
Just add the variables in lib/cubetech/localize.php
Reworked on lib/setup.php - actual version was without script registration and without good timed loading.
