### PR TITLE
added crossorigin for fixing ajax with gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,10 @@ gulp.task('watch', function() {
 		proxy: finalurl, snippetOptions: {
 			whitelist: ['/wp-admin/admin-ajax.php'],
 			blacklist: ['/wp-admin/**']
+		},
+		middleware: function (req, res, next) {
+			res.setHeader('Access-Control-Allow-Origin', '*');
+			next();
 		}
 	});
 	gulp.watch([path.source + 'styles/**/*'], ['styles']);


### PR DESCRIPTION
Header option for working with ajax - generated ajax url contains the real url, so cross origin is needed
